### PR TITLE
fix error that replaced signed DLLs with unsigned ones

### DIFF
--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -11,6 +11,8 @@ param(
 # See README.md for more details.
 #
 
+$ErrorActionPreference = "Stop"
+
 # This helper function comes from https://github.com/psake/psake - it allows us to terminate the
 # script if any executable returns an error code, which PowerShell won't otherwise do
 function Exec {
@@ -83,11 +85,12 @@ foreach ($project in $projects) {
     } else {
         ProgressMessage "[$project]: signing assemblies"
         Exec { signtool sign /f $certFile /p $password $dlls }
+        Exec { signtool verify /pa $dlls }
     }
 
     ProgressMessage "[$project]: creating package"
     del "src\$project\bin\Release\*.nupkg"
-    Exec { dotnet pack -c Release "src\$project" }
+    Exec { dotnet pack -c Release --no-build "src\$project" }
 }
 
 foreach ($project in $projects) {

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -85,7 +85,6 @@ foreach ($project in $projects) {
     } else {
         ProgressMessage "[$project]: signing assemblies"
         Exec { signtool sign /f $certFile /p $password $dlls }
-        Exec { signtool verify /pa $dlls }
     }
 
     ProgressMessage "[$project]: creating package"


### PR DESCRIPTION
This was a basic scripting mistake that prevented us from releasing signed assemblies. What happened was that they would be successfully signed (`signtool sign`), but then when it came to put them together into a package (`dotnet pack`), it was _rebuilding them all from scratch_, thereby losing the signatures. I didn't realize there's a parameter you need to pass to `dotnet pack` to make it _not_ rebuild everything.